### PR TITLE
exclude assets in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+src/assets/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🌈🐙 Rainbow Octopus
 
-<div align="center"><img src="src/assets/rainbow_octopus.png" alt="Rainbow Octopus Logo PNG" width="250" /></div>
+<div align="center"><img src="https://raw.githubusercontent.com/sayranfs/rainbow-octopus/refs/heads/main/src/assets/rainbow_octopus.png" alt="Rainbow Octopus Logo PNG" width="250" /></div>
 
 **Rainbow Octopus** is a Node.js package inspired by [chalk](https://www.npmjs.com/package/chalk) and [colors](https://www.npmjs.com/package/colors). It is designed to make terminal message formatting easier, focusing on **quick and straightforward debugging**.
 


### PR DESCRIPTION
This change will reduce the package size on npm by ~240kb.

- Added .npmignore to exclude src/assets/ from npm package
- Updated README.md to use an external link for the Rainbow Octopus logo image